### PR TITLE
Added a check for anchors and loads that are the same.

### DIFF
--- a/pywim/smartslice/job.py
+++ b/pywim/smartslice/job.py
@@ -113,6 +113,8 @@ class Job(WimObject):
         Check the step definitions
         '''
         errors = []
+        anchorFaces = []
+        loadFaces = []
 
         if self.chop.steps.is_empty():
             errors.append(val.InvalidSetup(
@@ -133,6 +135,9 @@ class Job(WimObject):
                         'No faces have been selected for anchor ' + bc.name,
                         'Select a face to apply the anchor'
                     ))
+                else:
+                    anchorFaces.append(bc.face)
+
 
             if step.loads.is_empty():
                 errors.append(val.InvalidSetup(
@@ -146,6 +151,14 @@ class Job(WimObject):
                         'No faces have been selected for load ' + load.name,
                         'Select a face to apply the load'
                     ))
+                else:
+                    loadFaces.append(load.face)
+
+        if any(check in anchorFaces for check in loadFaces):
+            errors.append(val.InvalidSetup(
+                'Selecting the same face for an anchor and a load is not allowed.',
+                'Please adjust anchors/loads accordingly.'
+            ))
 
         return errors
 


### PR DESCRIPTION
The error message probably needs work. If we want to display which anchors/loads that are in question I can do that as well, just need to swap things over to a dict and rewrite the check.

This should close UI #197
https://app.zenhub.com/workspaces/smartslice-5ef3719d317b88001a6dc21e/issues/tetonsim/is-cura-ui/197